### PR TITLE
replaced a dead link/fixed typo

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -116,9 +116,9 @@ const Footer = ({ classes, locale }) => {
               </a>
             </Grid>
             <Grid item xs>
-              <a href="https://www.asylumconnect.org/follow-us-subscribe">
+              <a href="https://asylumconnect.org/contact/">
                 <Typography variant="display3">
-                  Subscribe to our Newletter
+                  Subscribe to our Newsletter
                 </Typography>
               </a>
             </Grid>


### PR DESCRIPTION
Current link to "Subscribe to our Newsletter" is dead. Replaced it with "Contact" section link.

Porting over work that was done in the PR in the old app by @vovka26

 https://github.com/jeremyhatter/asylum-connect-1deg-catalog/pull/33