### PR TITLE
Fixing translation key for canada header

### DIFF
--- a/src/locale/en_CA.js
+++ b/src/locale/en_CA.js
@@ -5,7 +5,7 @@ export default {
   "LGBTQ centers": "LGBTQ centres",
   "Cultural centers": "Cultural centres",
   "Drop-in centers for LGBTQ youth": "Drop-in centres for LGBTQ youth",
-  "Welcome to the United States AsylumConnect catalog!": "Welcome to the Canada AsylumConnect catalog!",
+  "Welcome to the United States AsylumConnect Catalog!": "Welcome to the Canada AsylumConnect catalog!",
   "Physical evaluations for asylum claim": "Physical evaluations for refugee claim",
   "Asylum application": "Refugee claim",
   "Psychological evaluations for asylum claim": "Psychological evaluations for refugee claim",


### PR DESCRIPTION
In #6 we fixed the US header to capitalize the "C" in Catalog. But we didn't address how this might affect translation and locale