### PR TITLE
Fix/canada catalog capitalize

### DIFF
--- a/src/locale/en_CA.js
+++ b/src/locale/en_CA.js
@@ -5,7 +5,7 @@ export default {
   "LGBTQ centers": "LGBTQ centres",
   "Cultural centers": "Cultural centres",
   "Drop-in centers for LGBTQ youth": "Drop-in centres for LGBTQ youth",
-  "Welcome to the United States AsylumConnect Catalog!": "Welcome to the Canada AsylumConnect catalog!",
+  "Welcome to the United States AsylumConnect Catalog!": "Welcome to the Canada AsylumConnect Catalog!",
   "Physical evaluations for asylum claim": "Physical evaluations for refugee claim",
   "Asylum application": "Refugee claim",
   "Psychological evaluations for asylum claim": "Psychological evaluations for refugee claim",


### PR DESCRIPTION
Following #7, this change didn't make it into the last PR. Capitalizes the C in the Canada catalog header