### PR TITLE
Feature/organization page back btn

### DIFF
--- a/src/components/resource/Resource.js
+++ b/src/components/resource/Resource.js
@@ -375,7 +375,9 @@ class Resource extends React.Component {
             <div> {/******* DESKTOP *******/}
               <Tools 
                 {...props}
+                backText={"Back to Search Results"}
                 classes={classes} 
+                handleBackButtonClick={this.props.handleResourceBackButton}
                 handleTabClick={this.handleTabClickDesktop}
                 handleRequestOpen={this.props.handleRequestOpen}
                 resource={resource}

--- a/src/components/resource/Tools.js
+++ b/src/components/resource/Tools.js
@@ -20,14 +20,14 @@ const Tools = (props) => (
 				<AsylumConnectBackButton text={props.backText} onClick={props.handleBackButtonClick} />
 			</Grid>
 			:
-			''
+			null
 		}
 		{props.tabs ?
 			<Grid item xs={12} sm={12} md={5}>
 					<DetailHeaderTabs tabs={props.tabs} tab={props.tab} handleTabClick={props.handleTabClick} classes={props.classes} />
 			</Grid>
 			:
-			''
+			null
 		}
     <Grid item xs={12} sm={12} md={7} className={"pull-right "+props.classes.cushion}>
       <div className="center-align">

--- a/src/components/resource/Tools.js
+++ b/src/components/resource/Tools.js
@@ -13,13 +13,22 @@ import ShareIcon from '../icons/ShareIcon';
 
 const Tools = (props) => (
   <Grid container spacing={0} alignItems={props.tabs ? 'flex-end' : 'center'} justify='center' className={(props.tabs ? props.classes.header : '')+' '+props.classes.dividerSpacing}>
-    <Grid item xs={12} sm={12} md={5} lg={5}>
-      {props.tabs ?
-        <DetailHeaderTabs tabs={props.tabs} tab={props.tab} handleTabClick={props.handleTabClick} classes={props.classes} />
-      : 
-        <AsylumConnectBackButton text={props.backText} onClick={props.handleBackButtonClick} />
-      }
-    </Grid>
+    {props.handleBackButtonClick ?
+			<Grid item xs={12} sm={12} 
+				md={props.handleBackButtonClick && props.tabs ? 12 : 5}
+			>
+				<AsylumConnectBackButton text={props.backText} onClick={props.handleBackButtonClick} />
+			</Grid>
+			:
+			''
+		}
+		{props.tabs ?
+			<Grid item xs={12} sm={12} md={5}>
+					<DetailHeaderTabs tabs={props.tabs} tab={props.tab} handleTabClick={props.handleTabClick} classes={props.classes} />
+			</Grid>
+			:
+			''
+		}
     <Grid item xs={12} sm={12} md={7} className={"pull-right "+props.classes.cushion}>
       <div className="center-align">
         <SaveToFavoritesButton


### PR DESCRIPTION
Before tools.js would only render either back button or nav tabs, so it hasn't been thought through for a case when we want both on the same page.

I separated conditions for displaying back button and the tabs. If we pass `tabs` and/or `handleBackButtonClick` as props, `Tools` controller will decide what to render on the page. 

